### PR TITLE
Update load config mutation + bug fixes

### DIFF
--- a/.github/workflows/heroku_staging.yaml
+++ b/.github/workflows/heroku_staging.yaml
@@ -7,7 +7,7 @@ name: Heroku_Deployment
 
 on:
   push:
-    branches: [update-load-config-mutation]
+    branches: [main]
 
 jobs:
   builds_successfully:
@@ -29,7 +29,7 @@ jobs:
           heroku_app_name: "lane-server"
           heroku_email: "douglas.kt.wong@gmail.com"
           healthcheck: "https://lane-server.herokuapp.com/graphql/"
-          branch: update-load-config-mutation
+          branch: main
         env: # Variables in this section must start with HD_
           HD_DISABLE_COLLECTSTATIC: True # Disable collection of static pages for django
           HD_LANE_SECRET_KEY: ${{secrets.LANE_SECRET_KEY}}

--- a/.github/workflows/heroku_staging.yaml
+++ b/.github/workflows/heroku_staging.yaml
@@ -7,7 +7,7 @@ name: Heroku_Deployment
 
 on:
   push:
-    branches: [main]
+    branches: [update-load-config-mutation]
 
 jobs:
   builds_successfully:
@@ -29,7 +29,7 @@ jobs:
           heroku_app_name: "lane-server"
           heroku_email: "douglas.kt.wong@gmail.com"
           healthcheck: "https://lane-server.herokuapp.com/graphql/"
-          branch: main
+          branch: update-load-config-mutation
         env: # Variables in this section must start with HD_
           HD_DISABLE_COLLECTSTATIC: True # Disable collection of static pages for django
           HD_LANE_SECRET_KEY: ${{secrets.LANE_SECRET_KEY}}

--- a/apps/slow_control/mutation.py
+++ b/apps/slow_control/mutation.py
@@ -123,10 +123,10 @@ async def load_run_config(*_, id):
     existingPriority = []
     for conf in inDatabase:
         try:
-            if conf['runConfigStatus']['status'] == RunState['QUEUED']:
+            if conf.runConfigStatus['status'] == RunState['QUEUED']:
                 existingIDs.append(conf.id)
                 existingPriority.append(conf.priority)
-        except KeyError:
+        except AttributeError:
             pass
 
     if existingIDs:
@@ -136,9 +136,13 @@ async def load_run_config(*_, id):
     else:
         queuedRunConfig['priority'] = 0
 
-    _, _, status = await _update_run_config(id, queuedRunConfig)
+    updated_run_config, _, _, status = await _update_run_config(id, queuedRunConfig)
 
-    return slow_control_payload(message=f'Set RunConfig {id} to {RunState["QUEUED"]} at priority {queuedRunConfig["priority"]}', success=status)
+    return {
+        'message': f'Set RunConfig {id} to {RunState["QUEUED"]} at priority {queuedRunConfig["priority"]}',
+        'success': status,
+        'loadedRunConfig': updated_run_config,
+    }
 
 
 """

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ importlib-metadata==4.8.3
 incremental==21.3.0
 iniconfig==1.1.1
 mypy-extensions==0.4.3
-numpy==1.19.5
+numpy
 packaging==21.3
 pathspec==0.9.0
 platformdirs==2.4.0

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -101,7 +101,7 @@ type Mutation {
   If existing runs are queued, updates the priority to be lower than
   what is already in the queue
   """
-  loadRunConfig(id: ID!): SlowControlPayload!
+  loadRunConfig(id: ID!): LoadConfigPayload!
 
   """
   Instructs the slow control worker to

--- a/schema/slow_control.graphql
+++ b/schema/slow_control.graphql
@@ -257,14 +257,18 @@ enum TimeFrameOptionEnum {
 Describes the status of a run config file
 """
 enum RunConfigStatusEnum {
-  """
-  Describes the status of a run config file
-  """
+  "RunConfig is valid and ready to be loaded"
   READY
+  "Something is wrong with the settings in the RunConfig"
   INVALID
+  "RunConfig has been loaded and is waiting for the Slow Control to run"
   QUEUED
+  "The Slow Control has started this RunConfig"
   RUNNING
+  "The Slow Control has finished running the RunConfig without error"
   COMPLETED
+  "The Slow Control encountered an issue while running the RunConfig"
   RUNTIME_ERROR
+  "A stop command was issued to the slow control and has interrupted the run"
   STOPPED
 }

--- a/schema/slow_control.graphql
+++ b/schema/slow_control.graphql
@@ -221,6 +221,19 @@ type SlowControlPayload {
   success: Boolean!
 }
 
+"""
+Return value of a loadRunConfig mutation
+"""
+type LoadConfigPayload {
+  message: String!
+  success: Boolean!
+  """
+  Returns the RunConfig that was the mutation target
+  (for cache updating purposes)
+  """
+  loadedRunConfig: RunConfig!
+}
+
 enum DeviceOptionEnum {
   "Of options presented, user may select mulitple"
   SELECT_ONE


### PR DESCRIPTION
- Update `loadRunConfig` mutation payload to return the loaded RunConfig (for cache refreshing on Vite)
- Fix an attribute error caused by treating `runConfigStatus` as a dictionary key not an attribute in the django model
- Remove numpy version specification in `requirements.txt` to maintain compatibility with both production server python version (3.6) and Heroku deployment (3.10)
- Update docstrings on RunConfigStatus enum