### PR TITLE
Change staging deployment from Heroku to Railway

### DIFF
--- a/.github/workflows/heroku_staging.yaml
+++ b/.github/workflows/heroku_staging.yaml
@@ -13,7 +13,7 @@ jobs:
   builds_successfully:
     runs-on: ubuntu-20.04
     environment:
-      name: "Staging"
+      name: "Heroku Staging (Inactive)"
       url: "https://lane-server.herokuapp.com/graphql/"
 
     steps:

--- a/.github/workflows/railway_staging.yaml
+++ b/.github/workflows/railway_staging.yaml
@@ -7,7 +7,7 @@ name: Railway_Deployment
 
 on:
   push:
-    branches: [deploy-railway]
+    branches: [main]
 
 env: # Note that env variables are only accessible from within a `steps` context
   NODE_VERSION: 16.15.0

--- a/.github/workflows/railway_staging.yaml
+++ b/.github/workflows/railway_staging.yaml
@@ -39,3 +39,8 @@ jobs:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         # Note that environment variables LANE_SECRET_KEY, LANE_DEBUG, and DISABLE_COLLECTSTATIC
         # have been set on the railway environment
+
+      - name: Staging health check
+        uses: jtalk/url-health-check-action@v2
+        with:
+          url: https://lane-staging.up.railway.app/graphql/

--- a/.github/workflows/railway_staging.yaml
+++ b/.github/workflows/railway_staging.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     environment:
       name: "Staging"
-      # url: "https://lane-server.herokuapp.com/graphql/"
+      url: "lane-staging.up.railway.app"
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/railway_staging.yaml
+++ b/.github/workflows/railway_staging.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-20.04
     environment:
       name: "Staging"
-      url: "lane-staging.up.railway.app"
+      url: "https://lane-staging.up.railway.app/graphql/"
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/railway_staging.yaml
+++ b/.github/workflows/railway_staging.yaml
@@ -37,6 +37,5 @@ jobs:
         run: railway up
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
-          DISABLE_COLLECTSTATIC: True # Disable collection of static pages for django
-          LANE_SECRET_KEY: ${{secrets.LANE_SECRET_KEY}}
-          LANE_DEBUG: False
+        # Note that environment variables LANE_SECRET_KEY, LANE_DEBUG, and DISABLE_COLLECTSTATIC
+        # have been set on the railway environment

--- a/.github/workflows/railway_staging.yaml
+++ b/.github/workflows/railway_staging.yaml
@@ -1,0 +1,42 @@
+name: Railway_Deployment
+
+# This workflow simply deploys the repo to Railway
+# Configuration on the railway end is done
+# in requirements.txt, runtime.txt, and Procfile
+# in the root directory
+
+on:
+  push:
+    branches: [deploy-railway]
+
+env: # Note that env variables are only accessible from within a `steps` context
+  NODE_VERSION: 16.15.0
+
+jobs:
+  builds_successfully:
+    runs-on: ubuntu-20.04
+    environment:
+      name: "Staging"
+      # url: "https://lane-server.herokuapp.com/graphql/"
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Set up Node js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install Railway
+        run: npm i -g @railway/cli
+
+      - name: Deploy
+        run: railway up
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+          DISABLE_COLLECTSTATIC: True # Disable collection of static pages for django
+          LANE_SECRET_KEY: ${{secrets.LANE_SECRET_KEY}}
+          LANE_DEBUG: False

--- a/.github/workflows/railway_staging.yaml
+++ b/.github/workflows/railway_staging.yaml
@@ -39,8 +39,3 @@ jobs:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         # Note that environment variables LANE_SECRET_KEY, LANE_DEBUG, and DISABLE_COLLECTSTATIC
         # have been set on the railway environment
-
-      - name: Staging health check
-        uses: jtalk/url-health-check-action@v2
-        with:
-          url: https://lane-staging.up.railway.app/graphql/

--- a/LANE_server/settings.py
+++ b/LANE_server/settings.py
@@ -30,6 +30,7 @@ ALLOWED_HOSTS = [
     'localhost',
     '127.0.0.1',
     '.herokuapp.com',
+    '.up.railway.app',
 ]
 
 # For FE and BE hosted locally on different ports


### PR DESCRIPTION
## Change staging deployment to Railway

Add a workflow for deployment to Railway, as the Heroku free tier is closing down at the end of November

New staging link available:

https://lane-staging.up.railway.app/graphql/

Closes #24 

### To Do
- [x] Open a PR on the FE repo that points the AWS staging to the new BE link
- [x] Disable the Heroku deployment action on github 

