### PR TITLE
Minor RunConfig Schema Updates

### DIFF
--- a/apps/slow_control/common.py
+++ b/apps/slow_control/common.py
@@ -35,12 +35,12 @@ def run_config_payload(message, success, modified):
     }
 
 
-def steps_payload(message, success, modified, runConfigID):
+def steps_payload(message, success, modified, runConfigId):
     return {
         'message': message,
         'success': success,
         'modifiedStep': modified,
-        'runConfigID': runConfigID,
+        'runConfigId': runConfigId,
     }
 
 

--- a/apps/slow_control/mutation.py
+++ b/apps/slow_control/mutation.py
@@ -210,7 +210,7 @@ async def create_run_config_step(*_, runConfigId, step):
 
 
 @mutation.field('updateRunConfigStep')
-async def update_run_config_step(*_, runConfigId, step):
+async def update_run_config_step(*_, runConfigId=None, step):
     clean_step = clean_step_input(step)
     modified, runConfigId, status = await _update_run_config_step(clean_step)
     return steps_payload(
@@ -222,7 +222,7 @@ async def update_run_config_step(*_, runConfigId, step):
 
 
 @mutation.field('deleteRunConfigStep')
-async def delete_run_config_step(*_, runConfigId, stepID):
+async def delete_run_config_step(*_, runConfigId=None, stepID):
     modified = await _get_step(stepID)
     runConfig = await _get_runconfig_via_step(stepID)
     status = await _delete_run_config_step(stepID)

--- a/apps/slow_control/mutation.py
+++ b/apps/slow_control/mutation.py
@@ -21,6 +21,12 @@ Asynchronous database access
 
 
 @database_sync_to_async
+def _get_runconfig_via_step(id):
+    '''Returns the runconfig associated with a step'''
+    return RunConfigStep.objects.using(DATABASE).get(pk=id).runconfig
+
+
+@database_sync_to_async
 def _create_run_config(clean_run):
     '''Returns (created_run_config, success)'''
     try:
@@ -218,12 +224,13 @@ async def update_run_config_step(*_, runConfigId, step):
 @mutation.field('deleteRunConfigStep')
 async def delete_run_config_step(*_, runConfigId, stepID):
     modified = await _get_step(stepID)
+    runConfig = await _get_runconfig_via_step(stepID)
     status = await _delete_run_config_step(stepID)
     return steps_payload(
         modified=modified,
-        message=f'deleted step {modified.id} in RunConfig {modified.runConfig.id}',
+        message=f'deleted step {modified.id} in RunConfig {runConfig.id}',
         success=status,
-        runConfigId=modified.runConfig.id,
+        runConfigId=runConfig.id,
     )
 
 

--- a/apps/slow_control/mutation.py
+++ b/apps/slow_control/mutation.py
@@ -53,7 +53,7 @@ def _update_run_config(id, clean_run):
     updatedFields = []
     for attr in runConfigInputField:
         if clean_run[attr] is not None:
-            if attr is 'steps':  # Since steps is foreign key, updating is different
+            if attr == 'steps':  # Since steps is foreign key, updating is different
                 # Delete all old steps in the RunConfig and recreate new ones entirely
                 RunConfigStep.objects.using(DATABASE).filter(runconfig__id__exact=id).delete()
                 new_steps = [RunConfigStep(**step, runconfig=in_database) for step in clean_run['steps']]

--- a/apps/slow_control/mutation.py
+++ b/apps/slow_control/mutation.py
@@ -222,10 +222,10 @@ async def update_run_config_step(*_, runConfigId=None, step):
 
 
 @mutation.field('deleteRunConfigStep')
-async def delete_run_config_step(*_, runConfigId=None, stepID):
-    modified = await _get_step(stepID)
-    runConfig = await _get_runconfig_via_step(stepID)
-    status = await _delete_run_config_step(stepID)
+async def delete_run_config_step(*_, runConfigId=None, stepId):
+    modified = await _get_step(stepId)
+    runConfig = await _get_runconfig_via_step(stepId)
+    status = await _delete_run_config_step(stepId)
     return steps_payload(
         modified=modified,
         message=f'deleted step {modified.id} in RunConfig {runConfig.id}',

--- a/apps/slow_control/mutation.py
+++ b/apps/slow_control/mutation.py
@@ -222,10 +222,10 @@ async def update_run_config_step(*_, runConfigId=None, step):
 
 
 @mutation.field('deleteRunConfigStep')
-async def delete_run_config_step(*_, runConfigId=None, stepId):
-    modified = await _get_step(stepId)
-    runConfig = await _get_runconfig_via_step(stepId)
-    status = await _delete_run_config_step(stepId)
+async def delete_run_config_step(*_, runConfigId=None, stepID):
+    modified = await _get_step(stepID)
+    runConfig = await _get_runconfig_via_step(stepID)
+    status = await _delete_run_config_step(stepID)
     return steps_payload(
         modified=modified,
         message=f'deleted step {modified.id} in RunConfig {runConfig.id}',

--- a/apps/slow_control/mutation.py
+++ b/apps/slow_control/mutation.py
@@ -37,9 +37,9 @@ def _create_run_config(clean_run):
 
 
 @database_sync_to_async
-def _create_run_config_step(runConfigID, clean_step):
-    '''Returns (created_step, runConfigID, success) upon completion'''
-    run_config = RunConfig.objects.using(DATABASE).get(pk=runConfigID)
+def _create_run_config_step(runConfigId, clean_step):
+    '''Returns (created_step, runConfigId, success) upon completion'''
+    run_config = RunConfig.objects.using(DATABASE).get(pk=runConfigId)
     new_step = RunConfigStep(**clean_step, runconfig=run_config)
     new_step.save(using=DATABASE)
     return new_step, new_step.runconfig.id, True
@@ -68,7 +68,7 @@ def _update_run_config(id, clean_run):
 
 @database_sync_to_async
 def _update_run_config_step(clean_step):
-    '''Returns (created_step, runConfigID, success) upon completion'''
+    '''Returns (created_step, runConfigId, success) upon completion'''
     in_database = RunConfigStep.objects.using(DATABASE).get(pk=clean_step['id'])
 
     for attr in runConfigStepInputField:
@@ -191,39 +191,39 @@ Run Config Steps Mutations
 
 
 @mutation.field('createRunConfigStep')
-async def create_run_config_step(*_, runConfigID, step):
+async def create_run_config_step(*_, runConfigId, step):
     '''Add step into existing runconfig'''
     clean_step = clean_step_input(step)
-    modified, runConfigID, status = await _create_run_config_step(runConfigID, clean_step)
+    modified, runConfigId, status = await _create_run_config_step(runConfigId, clean_step)
     return steps_payload(
         modified=modified,
-        message=f'created step {modified.id} in RunConfig {runConfigID}',
+        message=f'created step {modified.id} in RunConfig {runConfigId}',
         success=status,
-        runConfigID=runConfigID,
+        runConfigId=runConfigId,
     )
 
 
 @mutation.field('updateRunConfigStep')
-async def update_run_config_step(*_, runConfigID, step):
+async def update_run_config_step(*_, runConfigId, step):
     clean_step = clean_step_input(step)
-    modified, runConfigID, status = await _update_run_config_step(clean_step)
+    modified, runConfigId, status = await _update_run_config_step(clean_step)
     return steps_payload(
         modified=modified,
-        message=f'created step {modified.id} in RunConfig {runConfigID}',
+        message=f'created step {modified.id} in RunConfig {runConfigId}',
         success=status,
-        runConfigID=runConfigID,
+        runConfigId=runConfigId,
     )
 
 
 @mutation.field('deleteRunConfigStep')
-async def delete_run_config_step(*_, runConfigID, stepID):
+async def delete_run_config_step(*_, runConfigId, stepID):
     modified = await _get_step(stepID)
     status = await _delete_run_config_step(stepID)
     return steps_payload(
         modified=modified,
         message=f'deleted step {modified.id} in RunConfig {modified.runConfig.id}',
         success=status,
-        runConfigID=modified.runConfig.id,
+        runConfigId=modified.runConfig.id,
     )
 
 

--- a/apps/slow_control/query.py
+++ b/apps/slow_control/query.py
@@ -68,9 +68,9 @@ async def resolve_run_config(*_, id):
 
 
 @query.field("getRunConfigStep")
-async def resolve_run_config_step(*_, stepID, runConfigId=None):
-    '''Fetch RunConfig, then search the steps for stepID. Return None if step not found'''
-    return await _get_step(stepID)
+async def resolve_run_config_step(*_, stepId, runConfigId=None):
+    '''Fetch RunConfig, then search the steps for stepId. Return None if step not found'''
+    return await _get_step(stepId)
 
 
 @query.field("getRunConfigs")

--- a/apps/slow_control/query.py
+++ b/apps/slow_control/query.py
@@ -68,7 +68,7 @@ async def resolve_run_config(*_, id):
 
 
 @query.field("getRunConfigStep")
-async def resolve_run_config_step(*_, stepID, runConfigID=None):
+async def resolve_run_config_step(*_, stepID, runConfigId=None):
     '''Fetch RunConfig, then search the steps for stepID. Return None if step not found'''
     return await _get_step(stepID)
 

--- a/apps/slow_control/query.py
+++ b/apps/slow_control/query.py
@@ -68,9 +68,9 @@ async def resolve_run_config(*_, id):
 
 
 @query.field("getRunConfigStep")
-async def resolve_run_config_step(*_, stepId, runConfigId=None):
-    '''Fetch RunConfig, then search the steps for stepId. Return None if step not found'''
-    return await _get_step(stepId)
+async def resolve_run_config_step(*_, stepID, runConfigId=None):
+    '''Fetch RunConfig, then search the steps for stepID. Return None if step not found'''
+    return await _get_step(stepID)
 
 
 @query.field("getRunConfigs")

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -49,7 +49,7 @@ type Query {
   getRunConfigStep(
     "Deprecated argument"
     runConfigId: ID
-    stepId: ID!
+    stepID: ID!
   ): RunConfigStep
 
   """
@@ -136,7 +136,7 @@ type Mutation {
   deleteRunConfigStep(
     "Deprecated argument"
     runConfigId: ID
-    stepId: ID!
+    stepID: ID!
   ): RunConfigStepPayload!
 
   """

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -48,7 +48,7 @@ type Query {
   """
   getRunConfigStep(
     "Deprecated argument"
-    runConfigID: ID
+    runConfigId: ID
     stepID: ID!
   ): RunConfigStep
 
@@ -102,10 +102,10 @@ type Mutation {
   createRunConfig(runConfig: RunConfigInput!): RunConfigPayload!
 
   """
-  Adds a new step to a run config (designated by runConfigID)
+  Adds a new step to a run config (designated by runConfigId)
   """
   createRunConfigStep(
-    runConfigID: ID!
+    runConfigId: ID!
     step: RunConfigStepInput!
   ): RunConfigStepPayload!
 
@@ -121,7 +121,7 @@ type Mutation {
   """
   updateRunConfigStep(
     "Deprecated argument"
-    runConfigID: ID
+    runConfigId: ID
     step: RunConfigStepUpdateInput!
   ): RunConfigStepPayload!
 
@@ -135,7 +135,7 @@ type Mutation {
   """
   deleteRunConfigStep(
     "Deprecated argument"
-    runConfigID: ID
+    runConfigId: ID
     stepID: ID!
   ): RunConfigStepPayload!
 

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -49,7 +49,7 @@ type Query {
   getRunConfigStep(
     "Deprecated argument"
     runConfigId: ID
-    stepID: ID!
+    stepId: ID!
   ): RunConfigStep
 
   """
@@ -136,7 +136,7 @@ type Mutation {
   deleteRunConfigStep(
     "Deprecated argument"
     runConfigId: ID
-    stepID: ID!
+    stepId: ID!
   ): RunConfigStepPayload!
 
   """

--- a/schema/slow_control.graphql
+++ b/schema/slow_control.graphql
@@ -73,7 +73,7 @@ type RunConfig {
   "Status of the RunConfig + error messages"
   runConfigStatus: RunConfigStatus
   "How long the run takes in total to complete [seconds]"
-  totalTime: Int!
+  totalTime: Float!
 }
 
 """
@@ -94,7 +94,7 @@ input RunConfigInput {
   "Status of the RunConfig + error messages"
   runConfigStatus: RunConfigStatusInput
   "How long the run takes in total to complete [seconds]"
-  totalTime: Int!
+  totalTime: Float!
 }
 """
 Updates the properties of a run with unique identifier `id`
@@ -116,7 +116,7 @@ input RunConfigUpdateInput {
   "Update the status and error messages of the RunConfig"
   runConfigStatus: RunConfigStatusInput
   "Update the total run time of the RunConfig"
-  totalTime: Int
+  totalTime: Float
 }
 
 "Status and associated error messages of a RunConfig"

--- a/schema/slow_control.graphql
+++ b/schema/slow_control.graphql
@@ -63,7 +63,7 @@ type RunConfig {
   "Last datetime [UTC] the runfile was modified and saved"
   lastSaved: Datetime
   "List of steps describing what occurs during the run"
-  steps: [RunConfigStep!]
+  steps: [RunConfigStep]!
   """
   Priority for the slow control worker to process a RunConfig
 

--- a/schema/slow_control.graphql
+++ b/schema/slow_control.graphql
@@ -63,7 +63,7 @@ type RunConfig {
   "Last datetime [UTC] the runfile was modified and saved"
   lastSaved: Datetime
   "List of steps describing what occurs during the run"
-  steps: [RunConfigStep]!
+  steps: [RunConfigStep!]!
   """
   Priority for the slow control worker to process a RunConfig
 

--- a/schema/slow_control.graphql
+++ b/schema/slow_control.graphql
@@ -232,7 +232,7 @@ type RunConfigStepPayload {
   (for cache updating purposes)
   """
   modifiedStep: RunConfigStep!
-  runConfigID: ID!
+  runConfigId: ID!
 }
 
 """

--- a/test/test_runconfig.py
+++ b/test/test_runconfig.py
@@ -198,7 +198,6 @@ class TestRunConfig:
     client = TestClient(application)  # starlette Test Client instance
 
     runConfigNames = ["test_config0", "test_config1"]
-    runConfigIDs = []
     runConfigFake = {name: None for name in runConfigNames}
     runConfigFakeExpected = {name: None for name in runConfigNames}
     numsteps = 20  # Number of steps per run config


### PR DESCRIPTION
## Changes
- Change field `runConfigID` to `runConfigId`
- Change `totalTime` field from `Int` to `Float`
- Change RunConfig schema from
```graphql
type RunConfig {
  steps: [RunConfigStep!]
}
``` 
to

```graphql
type RunConfig {
  steps: [RunConfigStep!]!
}
``` 

Closes #36 

## Bug fixes
- Fix a bug where a RunConfigStep's associated RunConfig was fetched improperly (in `deleteRunConfigStep`)
- Fix a bug where deprecated argument runConfigId was still expected by resolvers