### PR TITLE
Add production deployment scripts and configuration files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,13 +49,11 @@ The production server has Python 3.6.9 and Node js 16.15.1
 
 ### 6. Staging
 
-Heroku is utilized as a staging area test. When a PR is merged into `main`, github actions pushes the repo to Heroku for a build and then attempts to ping the graphql endpoint for a health check.
+Railway is utilized as a staging area for quality control. When a PR is merged into `main`, github actions pushes the repo to Railway for a build
 
-The staging endpoint is located at https://lane-server.herokuapp.com/graphql/
+The staging endpoint is located at https://lane-staging.up.railway.app/graphql/
 
-Heroku's file system is "ephemeral", which essentially means any file untracked by github does not persist on the Heroku side. This means that migrations applied to sqlite databases are not saved, data added/removed from sqlite databases via API interactions are not saved, a static security.py file does not persist, etc.
-
-Files related to configuration of Heroku deployment are `Procfile`, `requirements.txt`, `runtime.txt`. The github actions file related to staging deployment primarily just pushes the repo to Heroku (with some environment variables) and runs a health check.
+Files related to configuration of Railway deployment are `Procfile`, `requirements.txt`, `runtime.txt`. Railway uses [Nixpacks](https://nixpacks.com/docs/getting-started) for deployment (the same package that Heroku uses)
 
 ### 7. Databases
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ To update LANE-server on production, perform the following:
 ```bash
 # Assuming you are in the $HOME/LANE/LANE-server directory
 chmod u+x deploy-prod/deploy.sh
-./deploy-prod/deploy.sh # Doesn't matter which directory from which you call deploy.sh
+./deploy-prod/deploy.sh
 ```
 
 This will pause the production server, check for updates, and redeploy.
@@ -148,5 +148,3 @@ To run the test suite in development, simply start the venv and in the root dire
 ```bash
 pytest test
 ```
-
-###

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,9 +33,9 @@ The Ariadne-asgi application is a Starlette object, which breaks several depende
 
 ### 4. GraphQL Endpoints
 
-The websocket endpoint (for GraphQL Subscriptions) is located at `ws://localhost:8000/graphql/`
+The local websocket endpoint (for GraphQL Subscriptions) is located at `ws://localhost:8000/graphql/`
 
-The http endpoint (for Queries and Mutations) is located at `http://localhost:8000/graphql/`
+The local http endpoint (for Queries and Mutations) is located at `http://localhost:8000/graphql/`
 
 Django default settings are such that the `/` at the end of the above urls is _mandatory_
 
@@ -46,6 +46,42 @@ Ariadne implements [subscriptions-transport-ws](https://github.com/apollographql
 ### 5. Production server
 
 The production server has Python 3.6.9 and Node js 16.15.1
+
+To update the server on production, perform the following:
+
+```bash
+# Assuming you are in the LANE-server directory
+chmod u+x deploy-prod/deploy.sh
+./deploy-prod/deploy.sh # Doesn't matter which directory from which you call deploy.sh
+```
+
+To deploy to production for the first time, perform the following:
+
+1. In the folder `$HOME/LANE`, run `git clone https://github.com/dougUCN/LANE-server.git`. (The client repo should be cloned into the same folder). Your directory structure should look as follows:
+
+```
+LANE
+├── LANE-client
+└── LANE-server
+```
+
+2. Follow the installation directions for the server as per steps 1 -> 3 in the [README](README.md)
+3. Install supervisord
+
+```
+sudo apt install supervisor
+```
+
+4. Copy the contents of the file `/deploy-prod/lane.conf` to `/etc/supervisor/conf.d/lane.conf`
+5. Create a directory with `sudo mkdir /run/daphne/`
+6. Create the file `/usr/lib/tmpfiles.d/daphne.conf` with contents `/run/daphne 0755 root root`
+7. Launch supervisord
+
+```bash
+sudo supervisorctl reread
+sudo supervisorctl update
+sudo systemctl status supervisor
+```
 
 ### 6. Staging
 
@@ -104,3 +140,5 @@ To run the test suite in development, simply start the venv and in the root dire
 ```bash
 pytest test
 ```
+
+###

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,15 +45,21 @@ Ariadne implements [subscriptions-transport-ws](https://github.com/apollographql
 
 ### 5. Production server
 
+As of 12/15/2022, the production LANE-server may only be accessed on the LANL OCE network at http://nedm-macpro.lanl.gov/graphql/
+
 The production server has Python 3.6.9 and Node js 16.15.1
 
-To update the server on production, perform the following:
+To update LANE-server on production, perform the following:
 
 ```bash
-# Assuming you are in the LANE-server directory
+# Assuming you are in the $HOME/LANE/LANE-server directory
 chmod u+x deploy-prod/deploy.sh
 ./deploy-prod/deploy.sh # Doesn't matter which directory from which you call deploy.sh
 ```
+
+This will pause the production server, check for updates, and redeploy.
+
+**Note:** Changes to the `deploy-prod/lane.conf` file will not propagate to the actual supervisord config file located in production. This needs to be done manually
 
 To deploy to production for the first time, perform the following:
 
@@ -72,8 +78,8 @@ LANE
 sudo apt install supervisor
 ```
 
-4. Copy the contents of the file `/deploy-prod/lane.conf` to `/etc/supervisor/conf.d/lane.conf`
-5. Create a directory with `sudo mkdir /run/daphne/`
+4. Copy the contents of the file `/deploy-prod/lane.conf` to a new file `/etc/supervisor/conf.d/lane.conf`
+5. Create a directory with `sudo mkdir /run/daphne/` for use by supervisord
 6. Create the file `/usr/lib/tmpfiles.d/daphne.conf` with contents `/run/daphne 0755 root root`
 7. Launch supervisord
 
@@ -82,6 +88,8 @@ sudo supervisorctl reread
 sudo supervisorctl update
 sudo systemctl status supervisor
 ```
+
+**Note:** To access the LANE-server at http://nedm-macpro.lanl.gov/graphql/, the LANE-client repository will need to be deployed as per the `CONTRIBUTING.md` file [here](https://github.com/dougUCN/LANE-client), as the Nginx configuration file is located in the LANE-client repository
 
 ### 6. Staging
 

--- a/LANE_server/settings.py
+++ b/LANE_server/settings.py
@@ -31,13 +31,11 @@ ALLOWED_HOSTS = [
     '127.0.0.1',
     '.herokuapp.com',
     '.up.railway.app',
+    '.lanl.gov',
 ]
 
 # For FE and BE hosted locally on different ports
-CORS_ALLOWED_ORIGINS = [
-    "http://localhost:3000",
-    "http://ec2-44-202-29-2.compute-1.amazonaws.com",
-]
+CORS_ALLOWED_ORIGINS = ['*']
 
 # Application definition
 

--- a/LANE_server/settings.py
+++ b/LANE_server/settings.py
@@ -35,7 +35,11 @@ ALLOWED_HOSTS = [
 ]
 
 # For FE and BE hosted locally on different ports
-CORS_ALLOWED_ORIGINS = ['*']
+CORS_ALLOWED_ORIGINS = [
+    "http://localhost:3000",
+    "http://ec2-44-202-29-2.compute-1.amazonaws.com",
+    "http://nedm-macpro.lanl.gov",
+]
 
 # Application definition
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ http://127.0.0.1:8000/graphql/
 
 # Live Demo
 
-See the live demo [here](https://lane-server.herokuapp.com/graphql/)!
+See the live demo [here](https://lane-staging.up.railway.app/graphql/)!
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ git clone https://github.com/dougUCN/LANE-server.git
 
 ### 2. Setting up a virtual environment:
 
-In the project directory
+In the LANE-server directory
 
 ```
 python3 -m venv venv
@@ -33,7 +33,7 @@ python3 -m pip install -r requirements.txt
 
 ### 3. Generating a secret key
 
-In the project directory, with venv enabled, run
+In the LANE-server directory, with venv enabled, run
 
 ```
 python scripts/genSecurityFile.py # --debug True <-- Only use this flag if in development!
@@ -52,7 +52,7 @@ if [ -f ${path_to_LANE_server}/LANE_server/.security ]; then
 fi
 ```
 
-Then, to propagate these changes and reactivate the venv, in the project directory run
+Then, to propagate these changes and reactivate the venv, in the LANE-server directory run
 
 ```
 source ~/.bashrc
@@ -61,7 +61,7 @@ source venv/bin/activate
 
 ### 4. Running the server
 
-In the project directory, with venv enabled, run the following command to start the server:
+In the LANE-server directory, with venv enabled, run the following command to start the server:
 
 ```
 daphne LANE_server.asgi:application

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ git clone https://github.com/dougUCN/LANE-server.git
 
 ### 2. Setting up a virtual environment:
 
-In the root directory
+In the project directory
 
 ```
 python3 -m venv venv
@@ -33,7 +33,7 @@ python3 -m pip install -r requirements.txt
 
 ### 3. Generating a secret key
 
-In the root directory, with venv enabled, run
+In the project directory, with venv enabled, run
 
 ```
 python scripts/genSecurityFile.py # --debug True <-- Only use this flag if in development!
@@ -47,12 +47,12 @@ And add these lines to your `~/.bashrc` file
 
 ```
 ### LANE Server debug flag and secret key
-if [ -f${path_to_LANE_server}/LANE_server/.security ]; then
+if [ -f ${path_to_LANE_server}/LANE_server/.security ]; then
     . ${path_to_LANE_server}/LANE_server/.security
 fi
 ```
 
-Then, to propagate these changes and reactivate the venv, in the root directory run
+Then, to propagate these changes and reactivate the venv, in the project directory run
 
 ```
 source ~/.bashrc
@@ -61,7 +61,7 @@ source venv/bin/activate
 
 ### 4. Running the server
 
-In the root directory, with venv enabled, run the following command to start the server:
+In the project directory, with venv enabled, run the following command to start the server:
 
 ```
 daphne LANE_server.asgi:application

--- a/deploy-prod/deploy.sh
+++ b/deploy-prod/deploy.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo "Stopping supervisord"
+supervisorctl stop all
+
+echo "Jump to app folder"
+cd $HOME/LANE/LANE-server
+pwd
+
+git pull
+
+echo "Check for any dependency updates"
+source venv/bin/activate
+export https_proxy=http://proxyout.lanl.gov:8080
+pip install -r requirements.txt
+
+echo "Restart supervisord"
+supervisorctl start all

--- a/deploy-prod/deploy.sh
+++ b/deploy-prod/deploy.sh
@@ -7,6 +7,7 @@ echo "Jump to app folder"
 cd $HOME/LANE/LANE-server
 pwd
 
+git checkout -- deploy-prod/deploy.sh
 git pull
 
 echo "Check for any dependency updates"

--- a/deploy-prod/lane-server.conf
+++ b/deploy-prod/lane-server.conf
@@ -1,0 +1,27 @@
+[fcgi-program:asgi]
+# This is the config file for supervisord, located in /etc/supervisor/conf.d
+# Modified from https://channels.readthedocs.io/en/stable/deploying.html
+
+# TCP socket used by Nginx backend upstream
+socket=tcp://localhost:8000
+
+# Directory where your site's project files are located
+directory=/home/daq/LANE/LANE-server
+
+# Each process needs to have a separate socket file, so we use process_num
+# Make sure to update "mysite.asgi" to match your project name
+command=/bin/bash -c "source /home/daq/LANE/LANE-server/.security && /home/daq/LANE/LANE-server/venv/bin/daphne -u /run/daphne/daphne%(process_num)d.sock --fd 0 --access-log - --proxy-headers LANE_server.asgi:application"
+
+# Number of processes to startup, roughly the number of CPUs you have
+numprocs=2
+
+# Give each process a unique name so they can be told apart
+process_name=lane-server%(process_num)d
+
+# Automatically start and recover processes
+autostart=true
+autorestart=true
+
+# Choose where you want your log to go
+stdout_logfile=/home/daq/LANE/logs/server.log
+redirect_stderr=true


### PR DESCRIPTION
## Changes
- Modifies allowed hosts and CORS for LANL network
- Adds instructions to `CONTRIBUTING.md` for deployment to production
- Adds a copy of the supervisord process manager file used in production to the repository
- Adds a script for deployment to production (will need to be run on the production server manually)
- Removes additional references to Heroku in the documentation and changes to Railway